### PR TITLE
Add opponent team feature with weakness analysis 

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,7 +15,8 @@ from controller import (
     SignupController,
     SigninController,
     TeamController,
-    PlayerController
+    PlayerController,
+    OpponentController
 )
 
 from database.data_access_postgresql import (
@@ -52,8 +53,8 @@ player_data_access = PlayerDataAccess(db)
 
 
 # Register interactors
-signup_interactor = SignupInteractor(user_data_access)
-signin_interactor = SigninInteractor(user_data_access,)
+signup_interactor = SignupInteractor(user_data_access, team_data_access)
+signin_interactor = SigninInteractor(user_data_access, team_data_access)
 
 
 # Register controllers
@@ -65,12 +66,14 @@ signin_controller = SigninController(signin_interactor, app)
 user_blueprint = UserBlueprint(signup_controller, signin_controller)
 team_controller = TeamController(team_data_access)
 player_controller = PlayerController(player_data_access)
+opponent_controller = OpponentController(team_data_access)
 
 
 # Register Flask blueprints
 app.register_blueprint(user_blueprint.bp)
 app.register_blueprint(team_controller.bp)
 app.register_blueprint(player_controller.bp)
+app.register_blueprint(opponent_controller.bp)
 
 
 @app.route("/")

--- a/backend/controller/__init__.py
+++ b/backend/controller/__init__.py
@@ -2,3 +2,4 @@ from .signup_controller import SignupController
 from .signin_controller import SigninController
 from .team_controller import TeamController
 from .player_controller import PlayerController
+from .opponent_controller import OpponentController

--- a/backend/controller/opponent_controller.py
+++ b/backend/controller/opponent_controller.py
@@ -1,0 +1,277 @@
+from flask import Blueprint, request, jsonify
+from database.data_access_interface import TeamDataAccessInterface
+from controller.pitcher_grading_service import PitcherGradingService
+from controller.pitcher_recomender_service import PitcherRecommenderService
+from pybaseball import pitching_stats
+
+
+class OpponentController:
+    def __init__(self, team_data_access: TeamDataAccessInterface):
+        """
+        Controller for opponent team operations
+        """
+        self.team_data_access = team_data_access
+        self.bp = Blueprint("opponent", __name__)
+
+        # Register routes
+        self.bp.add_url_rule("/api/opponent/<int:opponent_team_id>/weaknesses", 
+                            view_func=self.get_opponent_weaknesses, 
+                            methods=["GET"])
+        self.bp.add_url_rule("/api/opponent/<int:opponent_team_id>/counter-lineup/<int:user_team_id>",
+                            view_func=self.get_counter_lineup,
+                            methods=["GET"])
+
+    def get_opponent_weaknesses(self, opponent_team_id):
+        """
+        Analyze opponent team and return only their weaknesses
+        """
+        try:
+            # Get all players on the opponent team
+            players = self.team_data_access.get_all_players(opponent_team_id)
+            if not players:
+                return jsonify({"error": "No players found for opponent team"}), 404
+
+            # Fetch MLB pitching stats (2025)
+            stats = pitching_stats(2025)
+            stats.columns = [c.strip().lower() for c in stats.columns]
+
+            # Analyze each pitcher and extract weaknesses
+            weaknesses_analysis = []
+            total_grade = 0
+            graded_count = 0
+
+            for p in players:
+                name = p.get("player_name")
+                match = stats[stats["name"].str.contains(name, case=False, na=False)]
+                
+                if match.empty:
+                    print(f"No stat match found for {name}")
+                    continue
+
+                row = match.iloc[0]
+                
+                # Calculate grade
+                pitcher_stats = {
+                    "K%": row.get("k%", 0),
+                    "IP": row.get("ip", 0),
+                    "ERA": row.get("era", 0)
+                }
+                
+                grade = PitcherGradingService.calculate_pitcher_grade(pitcher_stats)
+                total_grade += grade
+                graded_count += 1
+                
+                # Get full analysis
+                full_analysis = PitcherGradingService.analyze_pitcher(pitcher_stats, grade)
+                
+                # Extract only weaknesses from the analysis
+                weaknesses = self._extract_weaknesses(full_analysis, pitcher_stats, grade)
+                
+                weaknesses_analysis.append({
+                    "player_name": name,
+                    "position": p.get("position", "SP"),
+                    "grade": round(grade, 2),
+                    "weaknesses": weaknesses
+                })
+
+            avg_grade = round(total_grade / graded_count, 2) if graded_count > 0 else 0
+
+            return jsonify({
+                "opponent_team_id": opponent_team_id,
+                "average_grade": avg_grade,
+                "pitchers": weaknesses_analysis
+            }), 200
+
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return jsonify({"error": str(e)}), 500
+
+    def _extract_weaknesses(self, full_analysis: str, stats: dict, grade: float) -> str:
+        """
+        Extract only weakness-related information from the full analysis
+        """
+        k = stats.get("K%", 0) * 100
+        ip = stats.get("IP", 0)
+        era = stats.get("ERA", 0)
+        
+        weaknesses = []
+        
+        # Determine tier for context
+        if grade >= 80:
+            tier = "Elite"
+        elif grade >= 70:
+            tier = "Top"
+        elif grade >= 60:
+            tier = "Solid"
+        elif grade >= 45:
+            tier = "Replacement"
+        else:
+            tier = "Poor"
+        
+        # Extract weaknesses based on stats
+        if k < 20:
+            weaknesses.append(f"• Low strikeout production ({k:.1f}% K rate) limits fantasy ceiling.")
+        elif k < 24:
+            weaknesses.append(f"• Modest strikeout output ({k:.1f}% K rate) - can be exploited with high-contact hitters.")
+        
+        if ip < 130:
+            weaknesses.append(f"• Light innings load ({ip:.1f} IP) reduces overall fantasy impact.")
+        
+        if era > 4.25:
+            weaknesses.append(f"• High ERA ({era:.2f}) indicates vulnerability to runs - aggressive hitting approach recommended.")
+        elif era > 3.50:
+            weaknesses.append(f"• Inconsistent run prevention (ERA {era:.2f}) - can be exploited in favorable matchups.")
+        
+        # Add strategic recommendations based on weaknesses
+        if len(weaknesses) == 0:
+            weaknesses.append(f"• {tier} tier pitcher with no major exploitable weaknesses - requires disciplined at-bats.")
+        else:
+            if era > 4.00:
+                weaknesses.append("• Strategy: Focus on aggressive hitting to capitalize on poor run prevention.")
+            if k < 22:
+                weaknesses.append("• Strategy: Use contact-oriented hitters to exploit low strikeout rate.")
+        
+        return "\n".join(weaknesses)
+
+    def get_counter_lineup(self, opponent_team_id, user_team_id):
+        """
+        Recommend a lineup from user's team that exploits opponent's weaknesses
+        """
+        try:
+            # Get opponent weaknesses first
+            opponent_players = self.team_data_access.get_all_players(opponent_team_id)
+            if not opponent_players:
+                return jsonify({"error": "No opponent players found"}), 404
+            
+            # Get user's team players
+            user_players = self.team_data_access.get_all_players(user_team_id)
+            if not user_players:
+                return jsonify({"error": "No players found for your team"}), 404
+
+            # Fetch MLB pitching stats
+            stats = pitching_stats(2025)
+            stats.columns = [c.strip().lower() for c in stats.columns]
+
+            # Analyze opponent weaknesses
+            opponent_analysis = self._analyze_opponent_weaknesses(opponent_players, stats)
+            
+            # Get profile from query string, default to strategy based on opponent weaknesses
+            profile = request.args.get("profile")
+            if not profile:
+                profile = self._determine_counter_strategy(opponent_analysis)
+
+            # Enrich user's pitchers with stats
+            enriched_pitchers = []
+            for p in user_players:
+                name = p.get("player_name")
+                match = stats[stats["name"].str.contains(name, case=False, na=False)]
+                if match.empty:
+                    continue
+
+                row = match.iloc[0]
+                enriched_pitchers.append({
+                    "name": row["name"],
+                    "team": row.get("team", "Unknown"),
+                    "pitching+": row.get("pitching+", 100),
+                    "stuff+": row.get("stuff+", 100),
+                    "k-bb%": row.get("k-bb%", 0),
+                    "xfip-": row.get("xfip-", 100),
+                    "barrel%": row.get("barrel%", 0),
+                    "hardhit%": row.get("hardhit%", 0),
+                    "gb%": row.get("gb%", 0),
+                    "swstr%": row.get("swstr%", 0),
+                    "wpa/li": row.get("wpa/li", 0),
+                })
+
+            if not enriched_pitchers:
+                return jsonify({"error": "No matching MLB stats found for your team"}), 404
+
+            # Generate lineup recommendation
+            df, explanation = PitcherRecommenderService.recommend_starting_pitchers(
+                enriched_pitchers, 5, profile
+            )
+
+            records = df.to_dict(orient="records")
+            formatted = [
+                {
+                    "rank": int(r["rank"]),
+                    "name": r["name"],
+                    "position": "SP",
+                    "score": round(float(r["score"]), 2),
+                }
+                for r in records
+            ]
+
+            # Create enhanced explanation
+            counter_explanation = (
+                f"Counter-Strategy Analysis:\n\n"
+                f"Opponent Weaknesses Identified:\n{opponent_analysis['summary']}\n\n"
+                f"Recommended Strategy: {profile.upper()}\n\n"
+                f"{explanation}\n\n"
+                f"This lineup is optimized to exploit the opponent's vulnerabilities."
+            )
+
+            return jsonify({
+                "lineup": formatted,
+                "explanation": counter_explanation,
+                "strategy": profile,
+                "opponent_weaknesses": opponent_analysis
+            }), 200
+
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return jsonify({"error": str(e)}), 500
+
+    def _analyze_opponent_weaknesses(self, opponent_players, stats):
+        """Analyze opponent team to identify collective weaknesses"""
+        total_k = 0
+        total_era = 0
+        count = 0
+        
+        for p in opponent_players:
+            name = p.get("player_name")
+            match = stats[stats["name"].str.contains(name, case=False, na=False)]
+            if match.empty:
+                continue
+                
+            row = match.iloc[0]
+            total_k += row.get("k%", 0) * 100
+            total_era += row.get("era", 0)
+            count += 1
+        
+        if count == 0:
+            return {"summary": "Unable to analyze opponent", "avg_k": 0, "avg_era": 0}
+        
+        avg_k = total_k / count
+        avg_era = total_era / count
+        
+        weaknesses = []
+        if avg_k < 22:
+            weaknesses.append(f"Low strikeout rate (avg {avg_k:.1f}% K)")
+        if avg_era > 3.75:
+            weaknesses.append(f"High ERA (avg {avg_era:.2f})")
+        if not weaknesses:
+            weaknesses.append("Well-rounded staff with no major weaknesses")
+            
+        return {
+            "summary": " | ".join(weaknesses),
+            "avg_k": round(avg_k, 1),
+            "avg_era": round(avg_era, 2)
+        }
+    
+    def _determine_counter_strategy(self, opponent_analysis):
+        """Determine the best counter-strategy based on opponent weaknesses"""
+        avg_k = opponent_analysis.get("avg_k", 25)
+        avg_era = opponent_analysis.get("avg_era", 3.5)
+        
+        # If opponent has low K rate, use strikeout strategy
+        if avg_k < 22:
+            return "strikeout"
+        # If opponent has high ERA, use control/sabermetrics
+        elif avg_era > 4.0:
+            return "sabermetrics"
+        # Otherwise use standard
+        else:
+            return "standard"

--- a/backend/controller/signin_controller.py
+++ b/backend/controller/signin_controller.py
@@ -21,6 +21,7 @@ class SigninController:
                 {
                     "username": user["username"],
                     "userID": user["id"],
+                    "opponentTeamID": user.get("opponent_team_id"),
                     "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
                 },
                 self.app.config["SECRET_KEY"],

--- a/backend/controller/signup_controller.py
+++ b/backend/controller/signup_controller.py
@@ -11,7 +11,7 @@ class SignupController:
         data = request.get_json()
         username = data.get("username")
         password = data.get("password")
-        hashed_password = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode("utf-8")
+        hashed_password = bcrypt.hashpw(password.encode(), bcrypt.gensalt())
 
         try:
             user_data = self.signup_interactor.signup(username, hashed_password)

--- a/backend/database/data_access_interface.py
+++ b/backend/database/data_access_interface.py
@@ -38,6 +38,20 @@ class UserDataAccessInterface(ABC):
         """
         pass
 
+    @abstractmethod
+    def assign_opponent_team(self, username: str, opponent_team_id: int) -> Optional[UserEntity]:
+        """
+        Assign an opponent team to a user.
+        """
+        pass
+
+    @abstractmethod
+    def get_opponent_team_id(self, username: str) -> Optional[int]:
+        """
+        Get the opponent team ID assigned to a user.
+        """
+        pass
+
 
 # -------------------------
 # Team Interface
@@ -61,6 +75,14 @@ class TeamDataAccessInterface(ABC):
 
     @abstractmethod
     def get_all_players(self, team_id: int) -> List[dict]:
+        pass
+
+    @abstractmethod
+    def create_opponent_user_and_team(self) -> dict:
+        """
+        Create a new opponent user with a randomly generated team.
+        Returns dict with opponent_user_id, opponent_team_id, and opponent_username.
+        """
         pass
 
 

--- a/backend/database/entities/user_entity.py
+++ b/backend/database/entities/user_entity.py
@@ -5,6 +5,7 @@ class UserEntity:
         self.__id = id
         self.__username = username
         self.__password = password
+        self.opponent_team_id: Optional[int] = None
 
     def get_id(self) -> Optional[int]:
         return self.__id
@@ -23,3 +24,9 @@ class UserEntity:
 
     def set_password(self, password: Optional[bytes]) -> None:
         self.__password = password
+
+    def get_opponent_team_id(self) -> Optional[int]:
+        return self.opponent_team_id
+    
+    def set_opponent_team_id(self, opponent_team_id: Optional[int]) -> None:
+        self.opponent_team_id = opponent_team_id

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -1,7 +1,8 @@
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
     username VARCHAR(100) NOT NULL UNIQUE,
-    password BYTEA NOT NULL
+    password BYTEA NOT NULL,
+    opponent_team_id INT
 );
 
 

--- a/backend/interactors/signin_interactor.py
+++ b/backend/interactors/signin_interactor.py
@@ -1,10 +1,11 @@
-from database.data_access_interface import UserDataAccessInterface
+from database.data_access_interface import UserDataAccessInterface, TeamDataAccessInterface
 import bcrypt
 
 class SigninInteractor:
 
-    def __init__(self, user_data_access: UserDataAccessInterface):
+    def __init__(self, user_data_access: UserDataAccessInterface, team_data_access: TeamDataAccessInterface):
         self.user_data_access = user_data_access
+        self.team_data_access = team_data_access
 
     def signin(self, username: str, password: str):
 
@@ -20,6 +21,18 @@ class SigninInteractor:
 
         if not password_correct:
             raise Exception("Incorrect username or password.")
+        
+        # Check if user has an opponent team assigned
+        opponent_team_id = user_entity.get_opponent_team_id()
+        if not opponent_team_id:
+            # Assign a new opponent team
+            opponent_info = self.team_data_access.create_opponent_user_and_team()
+            self.user_data_access.assign_opponent_team(username, opponent_info["opponent_team_id"])
+            opponent_team_id = opponent_info["opponent_team_id"]
 
-        return {"username": user_entity.get_username(), "id": user_entity.get_id()}
+        return {
+            "username": user_entity.get_username(), 
+            "id": user_entity.get_id(),
+            "opponent_team_id": opponent_team_id
+        }
     

--- a/backend/interactors/signup_interactor.py
+++ b/backend/interactors/signup_interactor.py
@@ -1,9 +1,10 @@
-from database.data_access_interface import UserDataAccessInterface
+from database.data_access_interface import UserDataAccessInterface, TeamDataAccessInterface
 
 class SignupInteractor:
 
-    def __init__(self, user_data_access: UserDataAccessInterface):
+    def __init__(self, user_data_access: UserDataAccessInterface, team_data_access: TeamDataAccessInterface):
         self.user_data_access = user_data_access
+        self.team_data_access = team_data_access
 
     def signup(self, username: str, password: str):
 
@@ -15,6 +16,10 @@ class SignupInteractor:
             raise Exception("A user with the same username already exists.")
         
         user_entity = self.user_data_access.create(username, password)
+        
+        # Create and assign an opponent team
+        opponent_info = self.team_data_access.create_opponent_user_and_team()
+        self.user_data_access.assign_opponent_team(username, opponent_info["opponent_team_id"])
 
         return {"username": user_entity.get_username()}
     

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the scripts directory a Python package

--- a/backend/scripts/migrate_add_opponent_team.py
+++ b/backend/scripts/migrate_add_opponent_team.py
@@ -1,0 +1,61 @@
+"""
+Migration script to add opponent_team_id column to users table.
+Run this once if you have an existing database.
+Usage: python -m scripts.migrate_add_opponent_team
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path so we can import from backend modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+from database import Database
+
+load_dotenv()
+
+def migrate_add_opponent_team():
+    """Add opponent_team_id column to users table if it doesn't exist"""
+    
+    DSN = os.getenv("DSN")
+    if not DSN:
+        print("[ERROR] No DSN found in environment variables")
+        return
+    
+    db = Database(DSN)
+    
+    print("[INFO] Starting migration to add opponent_team_id column...")
+    
+    try:
+        # Check if column already exists
+        check_query = """
+        SELECT column_name 
+        FROM information_schema.columns 
+        WHERE table_name='users' AND column_name='opponent_team_id';
+        """
+        result = db.execute(check_query, fetchone=True)
+        
+        if result:
+            print("[INFO] Column opponent_team_id already exists. Migration not needed.")
+        else:
+            # Add the column
+            alter_query = """
+            ALTER TABLE users 
+            ADD COLUMN opponent_team_id INT;
+            """
+            db.execute(alter_query, fetchone=False)
+            print("[SUCCESS] Added opponent_team_id column to users table.")
+        
+        db.close()
+        print("\n[DONE] Migration completed successfully!")
+        
+    except Exception as e:
+        print(f"[ERROR] Migration failed: {e}")
+        import traceback
+        traceback.print_exc()
+        db.close()
+
+if __name__ == "__main__":
+    migrate_add_opponent_team()

--- a/backend/scripts/seed_opponent.py
+++ b/backend/scripts/seed_opponent.py
@@ -1,0 +1,57 @@
+"""
+Run this script once to manually seed the Test Opponent team in the database.
+Usage: python -m scripts.seed_opponent
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path so we can import from backend modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+from database import Database
+from database.data_access_postgresql import TeamDataAccess
+
+load_dotenv()
+
+def seed_opponent_team():
+    """Manually create the Test Opponent team with a fixed roster"""
+    
+    DSN = os.getenv("DSN")
+    if not DSN:
+        print("[ERROR] No DSN found in environment variables")
+        return
+    
+    db = Database(DSN)
+    team_data_access = TeamDataAccess(db)
+    
+    print("[INFO] Starting opponent team seeding...")
+    
+    try:
+        # Use the existing ensure_test_opponent method
+        result = team_data_access.ensure_test_opponent()
+        
+        print(f"[SUCCESS] Test Opponent team created/verified:")
+        print(f"  Team ID: {result.get('id')}")
+        print(f"  Team Name: {result.get('team_name')}")
+        print(f"  User ID: {result.get('user_id')}")
+        
+        # Verify players were added
+        players = team_data_access.get_all_players(result.get('id'))
+        print(f"[SUCCESS] Roster has {len(players)} players:")
+        for p in players:
+            print(f"  - {p.get('player_name')} ({p.get('position')})")
+        
+        db.close()
+        print("\n[DONE] Opponent team successfully seeded!")
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to seed opponent team: {e}")
+        import traceback
+        traceback.print_exc()
+        db.close()
+
+if __name__ == "__main__":
+    seed_opponent_team()

--- a/backend/test_db.py
+++ b/backend/test_db.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+import psycopg2
+
+load_dotenv()
+dsn = os.getenv("DSN")
+print(f"Testing connection with DSN: {dsn}")
+
+try:
+    conn = psycopg2.connect(dsn)
+    print("✓ Database connection successful!")
+    conn.close()
+except Exception as e:
+    print(f"✗ Connection failed: {e}")

--- a/frontend/app/config.ts
+++ b/frontend/app/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5006";

--- a/frontend/app/config.tsx
+++ b/frontend/app/config.tsx
@@ -1,2 +1,5 @@
-export const API_URL = "http://localhost:5006";
-// export const API_URL = import.meta.env.VITE_API_URL;
+// For browser (client-side), use localhost
+// For SSR (server-side), use container name
+export const API_URL = typeof window !== 'undefined' 
+  ? "http://localhost:5006" 
+  : "http://backend:5006";

--- a/frontend/app/counter-lineup-page/CounterLineupPage.tsx
+++ b/frontend/app/counter-lineup-page/CounterLineupPage.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from "react";
+import { API_URL } from "~/config";
+
+interface LineupPitcher {
+  rank: number;
+  name: string;
+  position: string;
+  score: number;
+}
+
+interface OpponentWeaknesses {
+  summary: string;
+  avg_k: number;
+  avg_era: number;
+}
+
+interface CounterLineupData {
+  lineup: LineupPitcher[];
+  explanation: string;
+  strategy: string;
+  opponent_weaknesses: OpponentWeaknesses;
+}
+
+export default function CounterLineupPage() {
+  const search =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams();
+
+  const opponentTeamId = search.get("opponentTeamId");
+  const userTeamId = search.get("userTeamId");
+
+  const [lineupData, setLineupData] = useState<CounterLineupData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!opponentTeamId || !userTeamId) {
+      setError("Missing team IDs.");
+      setLoading(false);
+      return;
+    }
+
+    const fetchCounterLineup = async () => {
+      try {
+        const res = await fetch(
+          `${API_URL}/api/opponent/${opponentTeamId}/counter-lineup/${userTeamId}`
+        );
+        if (!res.ok) throw new Error("Failed to fetch counter lineup");
+        const data = await res.json();
+        setLineupData(data);
+      } catch (e: any) {
+        setError(e.message || "Something went wrong.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCounterLineup();
+  }, [opponentTeamId, userTeamId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-white text-gray-900">
+        <p className="text-lg">Building optimal counter lineup...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-white text-gray-900">
+        <h1 className="text-2xl font-bold mb-4 text-red-600">Error</h1>
+        <p>{error}</p>
+        <a
+          href="/team-maker"
+          className="mt-6 bg-[#562424] text-white px-4 py-2 rounded-xl hover:bg-[#734343]"
+        >
+          Back to Team Maker
+        </a>
+      </div>
+    );
+  }
+
+  if (!lineupData) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-white py-10 text-gray-900">
+      <h1 className="text-4xl font-bold mb-4 text-green-600">
+        Counter Lineup Strategy
+      </h1>
+
+      <div className="w-full max-w-3xl mb-8 p-6 bg-green-50 border-2 border-green-200 rounded-xl">
+        <h2 className="text-2xl font-bold mb-3 text-green-700">
+          📊 Opponent Scouting Summary
+        </h2>
+        <p className="text-lg mb-2">
+          <strong>Weaknesses Identified:</strong> {lineupData.opponent_weaknesses.summary}
+        </p>
+        <p className="text-sm text-gray-700">
+          Avg K%: {lineupData.opponent_weaknesses.avg_k}% | 
+          Avg ERA: {lineupData.opponent_weaknesses.avg_era}
+        </p>
+      </div>
+
+      <div className="w-full max-w-3xl mb-8 p-6 bg-blue-50 border-2 border-blue-200 rounded-xl">
+        <h2 className="text-2xl font-bold mb-3 text-blue-700">
+          🎯 Counter-Strategy Explanation
+        </h2>
+        <p className="text-sm mb-2">
+          <strong>Selected Strategy:</strong>{" "}
+          <span className="text-blue-600 font-bold uppercase">
+            {lineupData.strategy}
+          </span>
+        </p>
+        <pre className="whitespace-pre-wrap text-sm text-gray-700 leading-relaxed">
+          {lineupData.explanation}
+        </pre>
+      </div>
+
+      <h2 className="text-2xl font-bold mb-4">Recommended Starting Lineup</h2>
+
+      <div className="w-full max-w-2xl overflow-hidden rounded-2xl border bg-green-50 shadow mb-8">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-green-200">
+            <tr>
+              <th className="px-3 py-2 font-semibold">Rank</th>
+              <th className="px-3 py-2 font-semibold">Name</th>
+              <th className="px-3 py-2 font-semibold">Position</th>
+              <th className="px-3 py-2 font-semibold text-right">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lineupData.lineup.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-3 py-4 text-center text-gray-500">
+                  No lineup recommendations available.
+                </td>
+              </tr>
+            ) : (
+              lineupData.lineup.map((p, index) => (
+                <tr key={index} className="border-t bg-white">
+                  <td className="px-3 py-2 font-bold text-green-600">
+                    #{p.rank}
+                  </td>
+                  <td className="px-3 py-2 font-medium">{p.name}</td>
+                  <td className="px-3 py-2 text-gray-700">{p.position}</td>
+                  <td className="px-3 py-2 text-gray-700 text-right font-semibold">
+                    {p.score}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-8 flex flex-col items-center gap-4">
+        <a
+          href={`/opponent-weaknesses?opponentTeamId=${opponentTeamId}&userTeamId=${userTeamId}`}
+          className="rounded-xl bg-red-600 text-white border border-red-600 px-6 py-2 text-sm font-semibold shadow hover:bg-red-700 transition-all"
+        >
+          View Opponent Weaknesses
+        </a>
+
+        <a
+          href={`/grading-display?teamId=${userTeamId}`}
+          className="rounded-xl bg-sky-400 text-white border border-sky-400 px-6 py-2 text-sm font-semibold shadow hover:bg-sky-500 transition-all"
+        >
+          Back to My Team
+        </a>
+
+        <a
+          href="/team-maker"
+          className="rounded-xl bg-gray-200 text-black px-6 py-2 text-sm font-semibold shadow hover:bg-gray-300 transition-all"
+        >
+          Back to Team Maker
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/grading-display-page/GradingDisplayPage.tsx
+++ b/frontend/app/grading-display-page/GradingDisplayPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { API_URL } from "~/config";
+import { getUserFromJWT } from "~/utils/getToken";
 
 interface Pitcher {
   player_name: string;
@@ -21,6 +22,7 @@ export default function GradingDisplayPage() {
   const [error, setError] = useState<string | null>(null);
   const [showProfileSelect, setShowProfileSelect] = useState(false);
   const [selectedProfile, setSelectedProfile] = useState("standard");
+  const [opponentTeamId, setOpponentTeamId] = useState<string | null>(null);
 
   const profiles = [
     { key: "standard", label: "Standard (Balanced)" },
@@ -32,6 +34,15 @@ export default function GradingDisplayPage() {
   ];
 
   useEffect(() => {
+    // Get opponent team ID from JWT token
+    const token = localStorage.getItem("jwtToken");
+    if (token) {
+      const userData = getUserFromJWT(token);
+      if (userData?.opponentTeamID) {
+        setOpponentTeamId(userData.opponentTeamID);
+      }
+    }
+
     if (!teamId) {
       setError("No team selected.");
       setLoading(false);
@@ -246,6 +257,15 @@ export default function GradingDisplayPage() {
             >
               Suggest Lineup
             </button>
+
+            {opponentTeamId && (
+              <a
+                href={`/opponent-weaknesses?opponentTeamId=${opponentTeamId}&userTeamId=${teamId}`}
+                className="rounded-xl bg-red-600 text-white border border-red-600 px-6 py-2 text-sm font-semibold shadow hover:bg-red-700 transition-all"
+              >
+                View Opponent Team
+              </a>
+            )}
 
             <a
               href="/team-maker"

--- a/frontend/app/opponent-weaknesses-page/OpponentWeaknessesPage.tsx
+++ b/frontend/app/opponent-weaknesses-page/OpponentWeaknessesPage.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from "react";
+import { API_URL } from "~/config";
+
+interface OpponentPitcher {
+  player_name: string;
+  position: string;
+  grade: number;
+  weaknesses: string;
+}
+
+interface OpponentData {
+  opponent_team_id: number;
+  average_grade: number;
+  pitchers: OpponentPitcher[];
+}
+
+export default function OpponentWeaknessesPage() {
+  const search =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams();
+
+  const opponentTeamId = search.get("opponentTeamId");
+  const userTeamId = search.get("userTeamId");
+  
+  const [opponentData, setOpponentData] = useState<OpponentData | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!opponentTeamId) {
+      setError("No opponent team ID provided.");
+      setLoading(false);
+      return;
+    }
+
+    const fetchOpponentWeaknesses = async () => {
+      try {
+        const res = await fetch(
+          `${API_URL}/api/opponent/${opponentTeamId}/weaknesses`
+        );
+        if (!res.ok) throw new Error("Failed to fetch opponent weaknesses");
+        const data = await res.json();
+        setOpponentData(data);
+      } catch (e: any) {
+        setError(e.message || "Something went wrong.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOpponentWeaknesses();
+  }, [opponentTeamId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-white text-gray-900">
+        <p className="text-lg">Analyzing opponent team...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-white text-gray-900">
+        <h1 className="text-2xl font-bold mb-4 text-red-600">Error</h1>
+        <p>{error}</p>
+        <a
+          href="/team-maker"
+          className="mt-6 bg-[#562424] text-white px-4 py-2 rounded-xl hover:bg-[#734343]"
+        >
+          Back to Team Maker
+        </a>
+      </div>
+    );
+  }
+
+  if (!opponentData) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-white py-10 text-gray-900">
+      <h1 className="text-4xl font-bold mb-4 text-red-600">
+        Opponent Team Analysis
+      </h1>
+
+      <p className="text-xl mb-6">
+        <span className="font-semibold">Opponent Average Grade:</span>{" "}
+        <span className="text-red-600 font-bold">{opponentData.average_grade}</span>
+      </p>
+
+      <div className="w-full max-w-2xl mb-8 p-4 bg-red-50 border-2 border-red-200 rounded-xl">
+        <h2 className="text-xl font-bold mb-2 text-red-700">
+          🎯 Scouting Report
+        </h2>
+        <p className="text-sm text-gray-700">
+          This page shows only the <strong>weaknesses</strong> of your opponent's pitchers.
+          Use this intelligence to build a counter-strategy and exploit their vulnerabilities.
+        </p>
+      </div>
+
+      <div className="w-full max-w-2xl overflow-hidden rounded-2xl border bg-red-50 shadow mb-8">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-red-200">
+            <tr>
+              <th className="px-3 py-2 font-semibold">Pitcher</th>
+              <th className="px-3 py-2 font-semibold">Position</th>
+              <th className="px-3 py-2 font-semibold text-right">Grade</th>
+              <th className="px-3 py-2 font-semibold text-right">Weaknesses</th>
+            </tr>
+          </thead>
+          <tbody>
+            {opponentData.pitchers.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-3 py-4 text-center text-gray-500">
+                  No opponent pitchers found.
+                </td>
+              </tr>
+            ) : (
+              opponentData.pitchers.map((p, index) => (
+                <React.Fragment key={index}>
+                  <tr
+                    className="border-t bg-white hover:cursor-pointer hover:bg-red-50"
+                    onClick={() => setExpanded(expanded === index ? null : index)}
+                  >
+                    <td className="px-3 py-2 font-medium">{p.player_name}</td>
+                    <td className="px-3 py-2 text-gray-700">{p.position}</td>
+                    <td className="px-3 py-2 text-gray-700 text-right font-semibold text-red-600">
+                      {p.grade}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <a className="text-red-600 hover:underline">
+                        {expanded === index ? "Hide" : "View"}
+                      </a>
+                    </td>
+                  </tr>
+
+                  {expanded === index && p.weaknesses && (
+                    <tr className="bg-red-50">
+                      <td colSpan={4} className="px-3 py-4">
+                        <div className="bg-white p-3 rounded border border-red-200">
+                          <h4 className="font-bold text-red-700 mb-2">
+                            Exploitable Weaknesses:
+                          </h4>
+                          <pre className="whitespace-pre-wrap text-sm text-gray-700">
+                            {p.weaknesses}
+                          </pre>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-8 flex flex-col items-center gap-4">
+        {userTeamId && (
+          <a
+            href={`/counter-lineup?opponentTeamId=${opponentTeamId}&userTeamId=${userTeamId}`}
+            className="rounded-xl bg-green-600 text-white border border-green-600 px-6 py-2 text-sm font-semibold shadow hover:bg-green-700 transition-all"
+          >
+            Build Counter Lineup
+          </a>
+        )}
+
+        <a
+          href={`/grading-display?teamId=${userTeamId}`}
+          className="rounded-xl bg-gray-200 text-black px-6 py-2 text-sm font-semibold shadow hover:bg-gray-300 transition-all"
+        >
+          Back to My Team
+        </a>
+
+        <a
+          href="/team-maker"
+          className="rounded-xl bg-gray-200 text-black px-6 py-2 text-sm font-semibold shadow hover:bg-gray-300 transition-all"
+        >
+          Back to Team Maker
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -4,5 +4,7 @@ export default [
     index("routes/home.tsx"),
     route("team-maker", "routes/team-maker.tsx"),
     route("grading-display", "routes/grading-display.tsx"),
-    route("lineup-recommendation", "routes/lineup-recommendation.tsx")
+    route("lineup-recommendation", "routes/lineup-recommendation.tsx"),
+    route("opponent-weaknesses", "routes/opponent-weaknesses.tsx"),
+    route("counter-lineup", "routes/counter-lineup.tsx")
 ] satisfies RouteConfig;

--- a/frontend/app/routes/counter-lineup.tsx
+++ b/frontend/app/routes/counter-lineup.tsx
@@ -1,0 +1,5 @@
+import CounterLineupPage from "~/counter-lineup-page/CounterLineupPage";
+
+export default function CounterLineupRoute() {
+  return <CounterLineupPage />;
+}

--- a/frontend/app/routes/opponent-weaknesses.tsx
+++ b/frontend/app/routes/opponent-weaknesses.tsx
@@ -1,0 +1,5 @@
+import OpponentWeaknessesPage from "~/opponent-weaknesses-page/OpponentWeaknessesPage";
+
+export default function OpponentWeaknessesRoute() {
+  return <OpponentWeaknessesPage />;
+}

--- a/frontend/app/sign-in-page/api/handleSubmit.tsx
+++ b/frontend/app/sign-in-page/api/handleSubmit.tsx
@@ -28,6 +28,9 @@ export async function handleSubmit(
   setMessage("Loading...");
   setLoading(true);
 
+  console.log('API_URL:', API_URL);
+  console.log('Attempting request to:', `${API_URL}/api/users/${mode}`);
+
   try {
     const res = await fetch(`${API_URL}/api/users/${mode}`, {
       method: "POST",
@@ -38,7 +41,9 @@ export async function handleSubmit(
       }),
     });
 
+    console.log('Response status:', res.status);
     const data = await res.json();
+    console.log('Response data:', data);
 
     if (res.ok) {
       setMessage(
@@ -62,9 +67,11 @@ export async function handleSubmit(
       setMessage(data.error || "Something went wrong");
     }
   } catch (err: unknown) {
+    console.error('Fetch error:', err);
     const messageText =
       err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
     setMessage(messageText || "Network error");
+    console.log('Error details:', messageText);
   } finally {
     setLoading(false);
   }

--- a/frontend/app/utils/getToken.ts
+++ b/frontend/app/utils/getToken.ts
@@ -1,11 +1,12 @@
-export function getUserFromJWT(token: string): { username?: string; userID?: string } | null {
+export function getUserFromJWT(token: string): { username?: string; userID?: string; opponentTeamID?: string } | null {
   if (!token) return null;
   try {
     const payload = token.split('.')[1];
     const decoded = JSON.parse(atob(payload));
     return {
       username: decoded.username,
-      userID: decoded.userID
+      userID: decoded.userID,
+      opponentTeamID: decoded.opponentTeamID
     };
   } catch {
     return null;

--- a/test-connection.html
+++ b/test-connection.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>API Connection Test</title>
+    <style>
+        body { font-family: Arial; padding: 20px; }
+        .success { color: green; }
+        .error { color: red; }
+        button { padding: 10px 20px; margin: 5px; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <h1>ROSTR API Connection Test</h1>
+    <div id="results"></div>
+    <hr>
+    <button onclick="testBackend()">Test Backend Health</button>
+    <button onclick="testSignup()">Test Signup</button>
+    <button onclick="testSignin()">Test Signin</button>
+
+    <script>
+        const API_URL = "http://localhost:5006";
+        const results = document.getElementById('results');
+
+        function log(message, isError = false) {
+            const p = document.createElement('p');
+            p.className = isError ? 'error' : 'success';
+            p.textContent = message;
+            results.appendChild(p);
+        }
+
+        async function testBackend() {
+            results.innerHTML = '';
+            log('Testing backend connection...');
+            try {
+                const response = await fetch(`${API_URL}/`);
+                const text = await response.text();
+                log(`✅ Backend: ${text}`);
+            } catch (err) {
+                log(`❌ Backend Error: ${err.message}`, true);
+            }
+        }
+
+        async function testSignup() {
+            results.innerHTML = '';
+            const username = 'testuser_' + Math.floor(Math.random() * 1000);
+            log(`Testing signup with username: ${username}...`);
+            try {
+                const response = await fetch(`${API_URL}/api/users/signup`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username, password: 'test123' })
+                });
+                const data = await response.json();
+                if (response.ok) {
+                    log(`✅ Signup Success: ${data.username}`);
+                } else {
+                    log(`❌ Signup Error: ${data.error}`, true);
+                }
+            } catch (err) {
+                log(`❌ Network Error: ${err.message}`, true);
+            }
+        }
+
+        async function testSignin() {
+            results.innerHTML = '';
+            log('Testing signin with vritidahiya...');
+            try {
+                const response = await fetch(`${API_URL}/api/users/signin`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username: 'vritidahiya', password: '123' })
+                });
+                const data = await response.json();
+                if (response.ok) {
+                    log(`✅ Signin Success: Got JWT token`);
+                    log(`Token: ${data.token.substring(0, 50)}...`);
+                } else {
+                    log(`❌ Signin Error: ${data.error}`, true);
+                }
+            } catch (err) {
+                log(`❌ Network Error: ${err.message}`, true);
+            }
+        }
+
+        // Auto-test on load
+        window.onload = () => {
+            testBackend();
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Feature Overview:
Adds a new feature that fetches the opponent's weekly roster and displays it to the user. It allows users to see their opponent's lineup and grades their own team against the opponent based on specific stats. NOTE: users can only see an opponent team's weaknesses, not strengths, to keep the game fair. 

Specifics:
- Fetch opponent team roster automatically from the database/API.
- Analyze opponent player stats and weaknesses.
- Compare the user's team against the opponent and provide a grade or score.
- Suggest counter-lineups, strategies, and player swaps based on opponent weaknesses.

### Related Issue
Closes #45  