### PR TITLE
Add strategy profile to trade evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,17 @@
   "packages": {
     "": {
       "dependencies": {
+        "@radix-ui/number": "^1.1.1",
         "lucide-react": "^0.553.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
     },
     "node_modules/lucide-react": {
       "version": "0.553.0",
@@ -24,7 +31,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@radix-ui/number": "^1.1.1",
     "lucide-react": "^0.553.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
Introduces a selectable fantasy strategy/profile to the trade evaluator UI and backend API, allowing users to choose evaluation criteria (e.g., strikeout-heavy, control, sabermetrics). The backend now returns a profile explanation, and the frontend displays it alongside trade results.