### PR TITLE
Rename 'Lineup' to 'Starting Rotation' in UI

### DIFF
--- a/frontend/app/components/navbar.tsx
+++ b/frontend/app/components/navbar.tsx
@@ -79,7 +79,7 @@ export function Navbar({ onNavigate, onOpenAuth }: NavbarProps) {
               Team Maker
             </button>
             <button onClick={() => navigateWithParams("/grading-display")} className={btnClassFor(["grading-display", "lineup-recommendation"])}>
-              Grading & Line-up Suggestion
+              Grading & Starting Rotation Suggestion
             </button>
             {/* include opponentTeamId for Opponent Team */}
             <button onClick={() => navigateWithParams("/opponent-weaknesses", true)} className={btnClassFor("opponent-weaknesses")}>

--- a/frontend/app/counter-lineup-page/CounterLineupPage.tsx
+++ b/frontend/app/counter-lineup-page/CounterLineupPage.tsx
@@ -120,7 +120,7 @@ export default function CounterLineupPage() {
         </pre>
       </div>
 
-      <h2 className="text-2xl font-bold mb-4">Recommended Starting Lineup</h2>
+      <h2 className="text-2xl font-bold mb-4">Recommended Starting Rotation</h2>
 
       <div className="w-full max-w-2xl overflow-hidden rounded-2xl border bg-green-50 shadow mb-8">
         <table className="min-w-full text-left text-sm">

--- a/frontend/app/grading-display-page/GradingDisplayPage.tsx
+++ b/frontend/app/grading-display-page/GradingDisplayPage.tsx
@@ -255,13 +255,13 @@ export default function GradingDisplayPage() {
               onClick={() => setShowProfileSelect(true)}
               className="rounded-xl bg-sky-400 text-white border border-sky-400 px-6 py-2 text-sm font-semibold shadow hover:bg-sky-500 transition-all"
             >
-              Suggest Lineup
+              Suggest Starting Rotation:
             </button>
           </>
         ) : (
           <div className="bg-sky-50 border rounded-2xl shadow p-4 flex flex-col items-center space-y-3">
             <label htmlFor="profile" className="font-semibold text-gray-800">
-              Choose Your Lineup Strategy:
+              Choose Your Rotation Strategy:
             </label>
             <select
               id="profile"
@@ -281,7 +281,7 @@ export default function GradingDisplayPage() {
                 href={`/lineup-recommendation?teamId=${teamId}&profile=${selectedProfile}`}
                 className="rounded-xl bg-sky-400 text-white border border-sky-400 px-4 py-2 text-sm font-semibold shadow hover:bg-sky-500"
               >
-                View Recommended Lineup
+                View Recommended Starting Rotation
               </a>
 
               <button

--- a/frontend/app/lineup-recommendation-page/LineupRecommendationPage.tsx
+++ b/frontend/app/lineup-recommendation-page/LineupRecommendationPage.tsx
@@ -71,7 +71,7 @@ export default function LineupRecommendationPage() {
 
   return (
     <div className="flex flex-col items-center min-h-screen bg-white py-10 text-gray-900">
-      <h1 className="text-4xl font-bold mb-6">Recommended Starting Lineup</h1>
+      <h1 className="text-4xl font-bold mb-6">Recommended Starting Rotation</h1>
 
       {/* Explanation Section */}
       <p className="max-w-3xl text-center text-lg text-gray-700 leading-relaxed mb-10 mx-auto px-4">


### PR DESCRIPTION
Updated various UI labels and button texts to use 'Starting Rotation' instead of 'Lineup' for consistency and clarity across navbar, grading display, counter lineup, and recommendation pages.